### PR TITLE
Remove `aws-account` resource type

### DIFF
--- a/examples/lab-robust/qwiklabs.yaml
+++ b/examples/lab-robust/qwiklabs.yaml
@@ -58,6 +58,7 @@ environment_resources:
   resources:
     - type: gcp_project
       id: my_primary_project
+      fleet: gcpfree
       dm_script: dm.zip
       default_region: 'us-central-1c'
     - type: gcp_user

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -154,36 +154,6 @@ environment_resources:
 
 #### Valid types
 
-##### AWS Account (aws-account)
-
-attribute | required | type           | notes
---------- | -------- | -------------- | ---------------------------------------
-cf_script |          | localized_path | Relative path to file in bundle
-variant   |          | enum           | This is equivalent to the current concept of Qwiklabs fleets
-
-```yml
-- type: aws-account
-  id: primary_account
-  variant: STS
-  cf_script:
-    locales:
-      en: cloudformation/intro-dynamo-db.yaml
-      es: cloudformation/intro-dynamo-db-es.yaml
-```
-
-```ruby
-# NOTE: Unreferenced properties on Lab model that we may also want to add here.
-t.decimal  "billing_limit"
-t.string   "aws_region"
-t.boolean  "global_set_vnc_password"
-t.boolean  "allow_aws_vpc_deletion"
-t.boolean  "allow_aws_subnet_deletion"
-t.boolean  "allow_aws_spot_instances"
-t.string   "allow_aws_ondemand_instances"
-t.boolean  "allow_aws_dedicated_instances"
-t.string   "allow_aws_rds_instances"
-```
-
 ##### GCP Project (gcp-project)
 
 attribute | required | type   | notes
@@ -237,8 +207,12 @@ roles       |          | dictionary | Specificy IAM roles per project
 
 ##### Future Resource Types
 
+- AWS Account (aws-account)
 - GSuite Domain (gsuite-domain)
 - iPython Notebook (ipython-notebook)
+
+> **NOTE:** A draft of the `aws-account` resource type was previously specified
+> in this document. See [previous version](https://github.com/CloudVLab/qwiklabs-content-bundle-spec/blob/93896ced4ae5b543132d7a10d838ac17bd5ae3e1/lab-bundle-spec.md) for details.
 
 ### Activity Tracking (Alpha)
 

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -186,25 +186,34 @@ t.string   "allow_aws_rds_instances"
 
 ##### GCP Project (gcp-project)
 
-attribute | required | type           | notes
---------- | -------- | -------------- | --------------------------------------
-dm_script |          | localized_path | relative path to file in bundle
-variant   |          | enum           | This is equivalent to the current concept of Qwiklabs fleets
+attribute | required | type   | notes
+--------- | -------- | -------| --------------------------------------
+dm_script |          | path   | A relative path to a Deployment Manager file.
+fleet     |          | enum*  | Specify the specific Qwiklabs fleet to pull the project from.
 
 ```yml
 - type: gcp-project
   id: secondary_project
-  variant: ASL
-  dm_script:
-    locales:
-      en: deployment_manager/instance_pool.yaml
-      es: deployment_manager/instance_poolb-es.yaml
+  fleet: gcpdfree
+  dm_script: deployment_manager/instance_pool.yaml
 ```
 
-```ruby
-# NOTE: Unreferenced properties on Lab model that we may also want to add here.
-t.string   "cloud_region",                              limit: 255
-```
+> **NOTE:** Not all GCP fleet names are supported.
+>
+> The existing concept of Qwiklabs' Fleets do not have a single analog in
+> content bundles. Notice that some fleet types map to resource types (e.g.
+> `gsuite_multi_tenant` fleet is now the `gsuite-domain` resource type).
+> However other fleets are "variants" of the same resource type (e.g.
+> "free", "ASL", and "standard" GCP projects). Therefore, the fleet
+>
+> Presently, authors are allowed to specify one of the following fleet types for
+> a gcp-project:
+> - gcpd [default]
+> - gcpfree
+> - gcpasl
+>
+> Future versions of the Content Bundle spec may use different terminology for
+> resource_type variations to avoid conflation.
 
 ##### GCP User (gcp-user)
 


### PR DESCRIPTION
This type is not supported yet, so I am removing it from the documentation to limit confusion.