### PR TITLE
Remove id fields from quiz bundle spec

### DIFF
--- a/examples/quiz-minimal/qwiklabs.yml
+++ b/examples/quiz-minimal/qwiklabs.yml
@@ -1,7 +1,6 @@
 entity_type: Quiz
 schema_version: 1
 
-id: quiz-minimal
 passing_percentage: 100
 default_locale: en
 

--- a/examples/quiz-robust/qwiklabs.yml
+++ b/examples/quiz-robust/qwiklabs.yml
@@ -1,7 +1,6 @@
 entity_type: Quiz
 schema_version: 1
 
-id: quiz-robust
 passing_percentage: 67
 default_locale: en
 

--- a/quiz-bundle-spec.md
+++ b/quiz-bundle-spec.md
@@ -12,7 +12,6 @@ Here's a sample `qwiklabs.yaml` file with all nested details removed to make it 
 entity_type: Quiz
 schema_version: 1
 
-id: final-exam
 passing_percentage: 67
 default_locale: en
 
@@ -27,7 +26,6 @@ attribute          | required | type    | notes
 -------------------| -------- | ------- | -----------------------------------------
 default_locale     | ✓        | string  | Corresponds to the locale that the quiz is authored in. Authoring tools can use this as a hint to notify localizers when content in the default locale is updated. Also, it provides a hint to the learner interface about which locale to display if an instruction/resource is not localized for the learner's current locale.
 schema_version     | ✓        | integer   | Which version of the quiz bundle schema you are using
-id                 | ✓        | string  | A unique identifier for this quiz, must be unique per "library" and URL friendly (think github org/repo)
 passing_percentage | ✓        | integer | The threshold grade that a student needs to achieve in order to count as "passing" the quiz.
 items              | ✓        | array   | An ordered array of `items` (see below for details) in this quiz - items will appear to students in this order
 
@@ -43,7 +41,6 @@ A quiz item that has multiple options and one answer. One option is the _answer_
 
 attribute | required | type       | notes
 ----------| -------- | -----------| -----------------------------------------
-id        | ✓        | string     | A unique identifier for this item
 type      | ✓        | string     | The item type, which is always `multiple-choice`
 stem      | ✓        | dictionary | A locale dictionary of the text that asks the question, such as "Which of the following is a color?"
 options   | ✓        | array      | An array of `options` (see below for details); order does not matter
@@ -54,7 +51,6 @@ A quiz item that has multiple options, any number of which are answers. Correct 
 
 attribute | required | type       | notes
 ----------| -------- | -----------| -----------------------------------------
-id        | ✓        | string     | A unique identifier for this item
 type      | ✓        | string     | The item type, which is always `multiple-select`
 stem      | ✓        | dictionary | A locale dictionary for the text that asks the question, such as "Which of the following is a color?"
 options   | ✓        | array      | An array of `options` (see below for details); order does not matter
@@ -66,7 +62,6 @@ A quiz item that has two predefined options: true and false. The correct option 
 
 attribute       | required | type       | notes
 ----------------| -------- | -----------| -----------------------------------------
-id              | ✓        | string     | A unique identifier for this item
 type            | ✓        | string     | The item type, which is always `true-false`
 stem            | ✓        | dictionary  | A locale dictionary of text that asks the question, such as "True or false: the world is round."
 answer          | ✓        | boolean     | The correct answer. `true` for "True", `false` for "False"
@@ -79,7 +74,6 @@ false_rationale | ✓        | string      | Explains why "False" is correct or 
 
 attribute    | required | type       | notes
 -------------| -------- | -----------| -----------------------------------------
-id        | ✓        | string     | A unique ID for this Option
 title     | ✓        | dictionary | A locale dictionary for the content of this option, such as "Blue"
 rationale | ✓        | dictionary | A locale dictionary for an explanation of why this option is correct or incorrect
 is_answer | ✓        | boolean    | `true` if this option is an answer, and `false` if it is a distractor


### PR DESCRIPTION
I'd previously added a top-level ID for quizzes as well as ID's on item,
item options, etc. None of that should be necessary.