### PR TITLE
Fix yaml list

### DIFF
--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -142,7 +142,7 @@ environment_resources:
       - project: my_primary_project
         roles:
           - roles/editor
-            roles/bigquery.admin
+          - roles/bigquery.admin
   - type: gcp_user
     id: secondary_user
 ```


### PR DESCRIPTION
This typo was copied into `qwiklab-website/test/bundles/`.  I fixed it in [this PR](https://github.com/CloudVLab/qwiklab-website/pull/2927), and figured I'd fix it here too while I'm at it.