### PR TITLE
Use new dm_template.script syntax in robust lab example

### DIFF
--- a/examples/lab-robust/qwiklabs.yaml
+++ b/examples/lab-robust/qwiklabs.yaml
@@ -61,7 +61,8 @@ environment_resources:
     - type: gcp_project
       id: my_primary_project
       fleet: gcpfree
-      dm_script: dm.zip
+      dm_template:
+        script: dm.zip
       default_region: 'us-central-1c'
     - type: gcp_user
       id: user_0


### PR DESCRIPTION
In https://github.com/CloudVLab/qwiklabs-content-bundle-spec/commit/3c1cfd73c5acfbf9d5b26598491b392675312f5a we updated the syntax for specifying dm template but did not update the example