### PR TITLE
v2 activity tracking spec

### DIFF
--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -333,7 +333,7 @@ attribute        | required | type                       | notes
 -----------------| -------- | ---------------------------| --------------------------------------
 title            | ✓        | locale dictionary          |
 maximum_score    | ✓        | integer                    | The maximum number of points this step can award.
-student_messages | ✓        | array of objects           | The keys are how the messages will be referenced in the code, and the values are locale dictionaries.
+student_messages | ✓        | dictionary of locale dictionaries           | The keys are how the messages will be referenced in the code, and the values are locale dictionaries.
 services         | ✓        | array of resource services | An array of services that will be used in the code block. Each resource type specifies a set of allowed services.
 code             | ✓        | string                     | Code to be executed. See [below](#code) for more information.
 

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -368,7 +368,7 @@ assessment:
       services:
         - target_project.StorageV1
       code: |-
-        def check(handles, max_score)
+        def check(handles: handles, resources: resources, maximum_score: maximum_score)
           storage_handle = handles['target_project.StorageV1']
 
           # Check for bucket
@@ -383,7 +383,7 @@ assessment:
             return { score: 2, student_message: 'bucket_misconfigured' }
           end
 
-          { score: max_score, student_message: 'success' }
+          { score: maximum_score, student_message: 'success' }
         end
     - title:
         locales:
@@ -413,7 +413,7 @@ assessment:
         - source_project.StorageV1
         - target_project.StorageV1
       code: |-
-        def check(handles, max_score)
+        def check(handles: handles, resources: resources, maximum_score: maximum_score)
           target_storage_handle = handles['target_project.StorageV1']
           source_storage_handle = handles['source_project.StorageV1']
 
@@ -430,7 +430,7 @@ assessment:
             return { score: 2, student_message: 'file_mismatch' }
           end
 
-          { score: max_score, student_message: 'success' }
+          { score: maximum_score, student_message: 'success' }
         end
 ```
 

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -374,16 +374,16 @@ assessment:
           # Check for bucket
           found_bucket = ...
           unless found_bucket
-            return { score: 0, message: 'bucket_missing' }
+            return { score: 0, student_message: 'bucket_missing' }
           end
 
           # Check bucket configuration
           bucket_configured_correctly = ...
           unless bucket_configured_correctly
-            return { score: 2, message: 'bucket_misconfigured' }
+            return { score: 2, student_message: 'bucket_misconfigured' }
           end
 
-          { score: max_score, message: 'success' }
+          { score: max_score, student_message: 'success' }
         end
     - title:
         locales:
@@ -420,17 +420,17 @@ assessment:
           # Check for file
           found_file = ...
           unless found_file
-            return { score: 0, message: 'file_missing' }
+            return { score: 0, student_message: 'file_missing' }
           end
 
           # Check file contents
           source_contents = ...
           target_contents = ...
           unless source_contents == target_contents
-            return { score: 2, message: 'file_mismatch' }
+            return { score: 2, student_message: 'file_mismatch' }
           end
 
-          { score: max_score, message: 'success' }
+          { score: max_score, student_message: 'success' }
         end
 ```
 
@@ -444,4 +444,4 @@ The method `check` will be called with two arguments:
 
 The method `check` should return a single hash with:
 - `:score`: the number of points the student earned.
-- `:message`: a key from the step's `student_messages` array, which will be presented to the student in the appropriate locale.
+- `:student_message`: a key from the step's `student_messages` array, which will be presented to the student in the appropriate locale.

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -368,7 +368,7 @@ assessment:
       services:
         - target_project.StorageV1
       code: |-
-        def check(handles)
+        def check(handles, max_score)
           storage_handle = handles['target_project.StorageV1']
 
           # Check for bucket
@@ -383,7 +383,7 @@ assessment:
             return { score: 2, message: 'bucket_misconfigured' }
           end
 
-          { score: 5, message: 'success' }
+          { score: max_score, message: 'success' }
         end
     - title:
         locales:
@@ -413,7 +413,7 @@ assessment:
         - source_project.StorageV1
         - target_project.StorageV1
       code: |-
-        def check(handles)
+        def check(handles, max_score)
           target_storage_handle = handles['target_project.StorageV1']
           source_storage_handle = handles['source_project.StorageV1']
 
@@ -430,7 +430,7 @@ assessment:
             return { score: 2, message: 'file_mismatch' }
           end
 
-          { score: 5, message: 'success' }
+          { score: max_score, message: 'success' }
         end
 ```
 
@@ -438,8 +438,9 @@ assessment:
 
 The code block must be valid Ruby code. It must have a method called `check`, and may optionally contain helper methods as well.
 
-The method `check` will be called with a single argument:
+The method `check` will be called with two arguments:
 - A map from `[RESOURCE].[SERVICE]` to a handle to that resource's service. It will only contain handles to services specified in the step's `services` array.
+- The maximum score for the step.
 
 The method `check` should return a single hash with:
 - `:score`: the number of points the student earned.


### PR DESCRIPTION
Add a spec for multi-resource activity tracking.

Of note:
- `manual`:
  - Omits `notify` (used 100 times out of 200,000) and declared legacy by [QL AT deck](https://docs.google.com/presentation/d/1H-di-0GzzSZNWWXyIg1oq29_3SX-fW6pR75L4Bqg7oU)
  -  Omits `score_completion_only` (used 160 times out of 200,000)
  - Omits `manual`, `manual_remote_url`, which are deprecated
  - Omits `name`, `description` (not sure what these would be for at the Manual level)
- `step`:
  - Allows title to be localized
  - Allows student-facing messages to be localized
  - Allows services from multiple resources
  - Omits `api` (since there might be multiple environment types)
  - Omits `max`, `interval` (QL code should be deciding these things [or, preferably IMO, removing the background checks altogether])
  - Omits `method_name`, and assumes the method to be called will be named `check` (other methods can still be created, and will not be called by the QL code)
  - Omits `multi_region` (this has caused lots of headaches and is only used 700 times out of 875,000)
- `step.code`:
  - Does not take `points` as an input (not sure why this would be useful)
  - Does not allow omitting a non-student message
  - Does not output a `done` key (will instead be inferred from `score == maximum_score`
  - Is still just a chunk of ruby code, rather than allowing for other languages or references to common modules


TODO: 
- add specification of allowed services in the various resource type sections
- update the `examples` directory