### PR TITLE
Add gcp_shell type to the bundle spec

### DIFF
--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -273,6 +273,8 @@ No additional attributes
 
 ##### GCP Shell (gcp_shell)
 
+> _PROPOSED ONLY: GCP Shell is not yet supported by Qwiklabs runtime._
+
 attribute   | required | type       | notes
 ----------- | -------- | ---------- | ----------------------------------------
 permissions | ✓        | array      | Array of project/roles(array) pairs

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -271,6 +271,23 @@ No additional attributes
   id: primary_domain
 ```
 
+##### GCP Shell (gcp_shell)
+
+attribute   | required | type       | notes
+----------- | -------- | ---------- | ----------------------------------------
+permissions | ✓        | array      | Array of project/roles(array) pairs
+
+```yml
+  - type: gcp_shell
+    id: shell
+    permissions:
+      - project: my_primary_project
+        roles:
+          - roles/editor
+```
+
+Note: Even though the spec supports any number of projects with any number roles, Qwiklabs only supports a shell having access to a single project and it must have the `roles/editor` role in that project. This note will be removed when Qwiklabs supports multiple projects and different roles for `gcp_shell`.
+
 ##### Future Resource Types
 
 - AWS Account (aws-account)


### PR DESCRIPTION
Add support for the `gcp_shell` resource type in the spec.

The format should look incredibly similar to `gcp_user`. As the "Note" explains, the spec supports arbitrary project + role combinations although our implementation will only support a single project with `roles/editor` for the time being. This will allow us to implement multiple projects or different roles without touching the spec in the future.

Like Cloud Shell currently, creators cannot specify startup scripts or do activity tracking on the shell itself. I know Josh and I also chatted about resource versioning and letting creators specify which version of the `gcp_shell` they want (possibly with the `variant` property but possibly with a different field). As we decide that those features should exist and implement them, we can update the spec to include the additional fields.

CC @hanysf @robsideshow @sabrina-gisselle @dcbrandao