### PR TITLE
Add Linux and Windows resources to the spec

### DIFF
--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -268,8 +268,6 @@ No additional attributes
 
 ##### Cloud Terminal (cloud_terminal)
 
-> _PROPOSED ONLY: Cloud Terminal is not yet supported by Qwiklabs runtime._
-
 attribute   | required | type       | notes
 ----------- | -------- | ---------- | ----------------------------------------
 permissions | ✓        | array      | Array of project/roles(array) pairs
@@ -284,6 +282,25 @@ permissions | ✓        | array      | Array of project/roles(array) pairs
 ```
 
 Note: Even though the spec supports any number of projects with any number roles, Qwiklabs only supports a shell having access to a single project and it must have the `roles/editor` role in that project. This note will be removed when Qwiklabs supports multiple projects and different roles for `cloud_terminal`.
+
+##### Linux Terminal (linux_terminal)
+
+attribute           | required | type  | notes
+------------------- | -------- | ------| ----------------------------------------
+permissions         | ✓        | array | Array of project/roles(array) pairs
+startup_script.path |          | path  | Relative path to a directory tree with the script contents.
+
+```yml
+  - type: linux_terminal
+    id: terminal
+    startup_script:
+      path: startup.sh
+```
+###### Valid custom property references
+
+The valid `reference`s for a `linux_terminal` resource are:
+
+- [LINUX_TERMINAL].public_ip
 
 ##### AWS Account (aws_account)
 
@@ -351,6 +368,25 @@ The valid `reference`s for an `aws_account` resource are:
 Qwiklabs regularly syncronizes it's list of EC2 instance types with the AWS platform. We purposefully do not provide a full list of EC2 instance types in this document, because AWS adds and deprecates instance types regularly.
 
 For a complete and up-to-date list of EC2 instance types, see [AWS official documentation](https://aws.amazon.com/ec2/instance-types/)
+
+##### Windows VM (windows_vm)
+
+attribute           | required | type  | notes
+------------------- | -------- | ------| ----------------------------------------
+permissions         | ✓        | array | Array of project/roles(array) pairs
+startup_script.path |          | path  | Relative path to a directory tree with the script contents.
+
+```yml
+  - type: windows_vm
+    id: vm
+    startup_script:
+      path: startup.ps1
+```
+###### Valid custom property references
+
+The valid `reference`s for a `windows_vm` resource are:
+
+- [WINDOWS_VM].public_ip
 
 #### Student Visible Outputs
 

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -300,7 +300,7 @@ startup_script.path |          | path  | Relative path to a directory tree with 
 
 The valid `reference`s for a `linux_terminal` resource are:
 
-- [LINUX_TERMINAL].public_ip
+- [LINUX_TERMINAL].external_ip
 
 ##### AWS Account (aws_account)
 
@@ -386,7 +386,7 @@ startup_script.path |          | path  | Relative path to a directory tree with 
 
 The valid `reference`s for a `windows_vm` resource are:
 
-- [WINDOWS_VM].public_ip
+- [WINDOWS_VM].external_ip
 
 #### Student Visible Outputs
 

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -387,6 +387,7 @@ startup_script.path |          | path  | Relative path to a directory tree with 
 The valid `reference`s for a `windows_vm` resource are:
 
 - [WINDOWS_VM].external_ip
+- [WINDOWS_VM].student_url (URL a student can open in a separate tab to see the Windows desktop experience)
 
 #### Student Visible Outputs
 

--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -287,7 +287,6 @@ Note: Even though the spec supports any number of projects with any number roles
 
 attribute           | required | type  | notes
 ------------------- | -------- | ------| ----------------------------------------
-permissions         | ✓        | array | Array of project/roles(array) pairs
 startup_script.path |          | path  | Relative path to a directory tree with the script contents.
 
 ```yml
@@ -373,7 +372,6 @@ For a complete and up-to-date list of EC2 instance types, see [AWS official docu
 
 attribute           | required | type  | notes
 ------------------- | -------- | ------| ----------------------------------------
-permissions         | ✓        | array | Array of project/roles(array) pairs
 startup_script.path |          | path  | Relative path to a directory tree with the script contents.
 
 ```yml


### PR DESCRIPTION
Our new Linux and Windows experiences are ready to get added to the spec! I believe all of the spec changes in this PR are already available on Qwiklabs. Some of them aren't available across all deployments but I don't think the specifics of that belong in the spec or should prevent us from including these in the spec.