### PR TITLE
add secret_access_key for aws_account

### DIFF
--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -363,6 +363,7 @@ reference                          | displayed as
 [AWS_ACCOUNT].username             | copyable text
 [AWS_ACCOUNT].password             | copyable text
 [AWS_ACCOUNT].access_key_id        | copyable text
+[AWS_ACCOUNT].secret_access_key    | copyable text
 [AWS_ACCOUNT].rdp_credentials      | copyable text
 [AWS_ACCOUNT].ssh_credentials      | copyable text
 [AWS_ACCOUNT].console_url          | button


### PR DESCRIPTION
Added the `secret_access_key` reference for `aws_account` resource after 
https://github.com/CloudVLab/git-whisperer/pull/176
and 
https://critique-ng.corp.google.com/cl/335454709
were deployed.