### PR TITLE
Add has_workspace_state field on gcp_user

### DIFF
--- a/lab-bundle-spec.md
+++ b/lab-bundle-spec.md
@@ -241,9 +241,10 @@ Any custom outputs being generated with a `startup_script` can be reference as [
 
 ##### GCP User (gcp_user)
 
-attribute   | required | type       | notes
------------ | -------- | ---------- | ----------------------------------------
-permissions |          | array      | Array of project/roles(array) pairs
+attribute           | required | type       | notes
+------------------- | -------- | ---------- | ----------------------------------------
+permissions         |          | array      | Array of project/roles(array) pairs
+has_workspace_state |          | boolean    | Set to `true` if this user will be used for Google Workspace activities (like Drive or Calendar)
 
 ```yml
   - type: gcp_user


### PR DESCRIPTION
We need a mechanism for letting labs opt-out of using a sticky user for the handful of labs that are incompatible. I'd like to avoid something like `opt_out_of_sticky_user: true` because the feature should only be disabled in limited situations that may change over time.

Right now, we believe the only situation is when a user is used for Google Workspace stuff. In the future, if we decide to start cleaning Workspace, we'd stop honoring this flag. Also in the future, if we discover there's a new class of features that we can't clean, we could add another flag letting creators indicate that the lab needs those special features. The end result is creators specify what the users are used for and we decide if we can recycle users given our current functionality.