### PR TITLE
lang= -> language= on ql-code-block elements

### DIFF
--- a/html/html-spec.md
+++ b/html/html-spec.md
@@ -91,7 +91,7 @@ Result:
 A `<ql-code-block>` on its own without tabs, in "output mode".
 
 ```html
-<ql-code-block lang="json" output>
+<ql-code-block language="json" output>
   {
     "id": 321,
     "age": 6,


### PR DESCRIPTION
I don't believe `lang=` is supported.