### PR TITLE
Bundle updates for qwiklabs scripts

### DIFF
--- a/api/lab-bundle-spec.md
+++ b/api/lab-bundle-spec.md
@@ -179,7 +179,7 @@ environment:
 
 attribute                        | required | type    | notes
 ---------------------------------| -------- | ------- | --------------------------------------
-startup_script.type              |          | string  | The type of startup script. Only `deployment_manager` is supported.
+| startup_script.type              | ✓        | string | The type of startup script. Only `deployment_manager` and `qwiklabs` are supported. |
 startup_script.path              |          | path    | Relative path to a directory tree with the script contents.
 startup_script.custom_properties |          | array   | Array of pairs. See below for details.
 ssh_key_user                     |          | string  | If this project should use a user's SSH key, the id of that user.

--- a/api/lab-bundle-spec.md
+++ b/api/lab-bundle-spec.md
@@ -179,7 +179,7 @@ environment:
 
 attribute                        | required | type    | notes
 ---------------------------------| -------- | ------- | --------------------------------------
-| startup_script.type              | ✓        | string | The type of startup script. Only `deployment_manager` and `qwiklabs` are supported. |
+startup_script.type              | ✓        | string  | The type of startup script. Only `deployment_manager` and `qwiklabs` are supported.
 startup_script.path              |          | path    | Relative path to a directory tree with the script contents.
 startup_script.custom_properties |          | array   | Array of pairs. See below for details.
 ssh_key_user                     |          | string  | If this project should use a user's SSH key, the id of that user.

--- a/github-lab-bundle-spec.md
+++ b/github-lab-bundle-spec.md
@@ -235,7 +235,7 @@ environment:
 
 attribute                        | required | type    | notes
 ---------------------------------| -------- | ------- | --------------------------------------
-startup_script.type              |          | string  | The type of startup script. Only `deployment_manager` is supported.
+startup_script.type              | ✓        | string  | The type of startup script. Only `deployment_manager` and `qwiklabs` are supported.
 startup_script.path              |          | path    | Relative path to a directory tree with the script contents.
 startup_script.custom_properties |          | array   | Array of pairs. See below for details.
 ssh_key_user                     |          | string  | If this project should use a user's SSH key, the id of that user.


### PR DESCRIPTION
Mark the script type as required, which in the code, it has been all along and document the new option for the `qwiklabs` script type.