### PR TITLE
Specify that resource IDs are required

### DIFF
--- a/api/lab-bundle-spec.md
+++ b/api/lab-bundle-spec.md
@@ -158,7 +158,7 @@ The properties of each environment resource will depend on their type, e.g. AWS 
 attribute | required | type   | notes
 --------- | -------- | ------ | -----------------------------------------
 type      | ✓        | enum   | [See list of valid types]
-id        |          | string | Identifier that can be used throughout project bundle.
+id        | ✓        | string | Identifier that can be used throughout project bundle.
 variant   |          | string | The subtype resource being requested. Each type below lists its valid variants and specifies which is the default.
 
 ```yml


### PR DESCRIPTION
CC @davetchen @jenaepennie

All existing labs fill in this field and we've been writing code assuming this field is always filled in.