### PR TITLE
Mention gcpondemand in bundle spec

### DIFF
--- a/api/lab-bundle-spec.md
+++ b/api/lab-bundle-spec.md
@@ -216,6 +216,7 @@ The allowed variants are:
 
 - gcpd [default]
 - gcpfree
+- gcpondemand
 - gcp_very_low_base
 - gcp_low_extra
 - gcp_medium_extra


### PR DESCRIPTION
We now support this variant for V2 labs.