### PR TITLE
Update game spec doc regarding document steps

### DIFF
--- a/game-template-bundle-spec.md
+++ b/game-template-bundle-spec.md
@@ -13,3 +13,4 @@ following exceptions:
 *   `entity_type` should be set to `GameTemplate`.
 *   `GameTemplate` does not have a `max_hot_labs` field.
 *   `GameTemplate` does not have an `instructor_resources` section.
+*   For games, if a step only contains activities with the type `resource`, the step will be optional by default. If you would like the step to be required, this can be overrided by setting `optional: false` for the step.

--- a/game-template-bundle-spec.md
+++ b/game-template-bundle-spec.md
@@ -13,4 +13,4 @@ following exceptions:
 *   `entity_type` should be set to `GameTemplate`.
 *   `GameTemplate` does not have a `max_hot_labs` field.
 *   `GameTemplate` does not have an `instructor_resources` section.
-*   For games, if a step only contains activities with the type `resource`, the step will be optional by default. If you would like the step to be required, this can be overrided by setting `optional: false` for the step.
+*   For `GameTemplate`s, if a step only contains activities with the type `resource`, the step will be optional by default. If you would like the step to be required, this can be overridden by setting `optional: false` for the step.


### PR DESCRIPTION
This PR adds documentation for game bundle specs explaining that steps containing only documents are optional by default.