### PR TITLE
Remove note on LearningPath description

### DIFF
--- a/learning-path-bundle-spec.md
+++ b/learning-path-bundle-spec.md
@@ -12,6 +12,5 @@ following exceptions:
 
 *   `entity_type` should be set to `LearningPath`.
 *   `LearningPath` does not have a `max_hot_labs` field.
-*   `LearningPath` can have a `resources` section.
 *   `LearningPath` does not have an `instructor_resources` section.
 *   `LearningPath` must have exactly 1 module.


### PR DESCRIPTION
Based on https://chat.google.com/room/AAAAamXn7ho/rKhnrD-1Ylw, `LearningPaths` (aka the templates for Quests) and `CourseTemplates` both have resources. 

The 3rd bullet in the `LearningPathBundleSpec` description is confusing because it is supposed to be a bulleted list of things that are *different* from `CourseTemplates`.  This PR removes the bullet to reduce confusion.

