### PR TITLE
Updated jupyter notebook with activity tracking documentation

### DIFF
--- a/github-lab-bundle-spec.md
+++ b/github-lab-bundle-spec.md
@@ -919,7 +919,7 @@ chmod 777 /home/jovyan/work/README.txt
 ###### Activity Tracking
 
 Jupyter Notebook resources offer activity tracking through nbgrader. To use activity tracking,
-it is a prerequisite to set up your `main.ipynb' file for scoring through nbgrader. Visit
+it is a prerequisite to set up your `main.ipynb` file for scoring through nbgrader. Visit
 [go/ql-jupyter-notebook-activity-tracking](go/ql-jupyter-notebook-activity-tracking) for
 instructions on how to do this.
 

--- a/github-lab-bundle-spec.md
+++ b/github-lab-bundle-spec.md
@@ -881,7 +881,7 @@ student_files       |          | path | Relative path to a directory student fil
 ###### Student Files
 
 Student files specified in the qwiklabs.yaml will be added to the directory
-`/home/jovyan/work`, which will the default directory opened on the file
+`/home/jovyan/work`, which will be the default directory opened on the file
 browser when the student opens the lab.
 
 When taking the lab, the student will have access to

--- a/github-lab-bundle-spec.md
+++ b/github-lab-bundle-spec.md
@@ -882,26 +882,21 @@ student_files       |          | path | Relative path to a directory student fil
 
 Student files specified in the qwiklabs.yaml will be added to the directory
 `/home/jovyan/work`, which will the default directory opened on the file
-browser when the student opens the lab:
-
-https://screenshot.googleplex.com/6DFLyQvXEV8aqG5
+browser when the student opens the lab.
 
 When taking the lab, the student will have access to
-everything in the `/home/jovyan` directory, but will not have access to the
-parent directory `/home`. As shown in the previous image, the root directory
-from the perspective of the student is `/home/jovyan`.
+everything in the `/home/jovyan` directory and `/home/jovyan`
+will be the root directory from the perspective of the student.
+The student will not have access to the parent directory `/home`
 
 By default, the lab will display an empty `main.ipynb` file on startup.
 If you include your own `main.ipynb` file in the student files, the lab
 will display your custom `main.ipynb` file on startup instead.
 
 For notebooks with activity tracking, all files accessed by the notebook
-MUST be in the same directory as `main.ipynb`.
+MUST be in the same directory as `main.ipynb` (the `/home/jovyan/work` directory).
 
 ###### Startup Scripts
-
-Startup scripts are executed from `/home/jovyan` which is the directory where
-Jupyter Notebook is installed.
 
 Startup scripts are run as root, but the student accesses the notebook as the
 unprivileged Jovyan user. Thus, if your startup script creates any files or


### PR DESCRIPTION
Added activity tracking documentation for jupyter notebooks.

To use in conjunction with: https://critique.corp.google.com/cl/725842802
I don't know if we can use go links in the bundle spec (not sure if they have access). Let me know if so!